### PR TITLE
feat(sebmGoogleMapMarker): support basic label

### DIFF
--- a/src/components/google_map_marker.ts
+++ b/src/components/google_map_marker.ts
@@ -9,6 +9,7 @@ export class SebmGoogleMapMarker {
   @Input() latitude: number;
   @Input() longitude: number;
   @Input() title: string;
+  @Input() label: string;
 
   private _markerAddedToManger: boolean = false;
   private _id: string;
@@ -26,6 +27,9 @@ export class SebmGoogleMapMarker {
     }
     if (changes['title']) {
       this._markerManager.updateTitle(this);
+    }
+    if (changes['label']) {
+      this._markerManager.updateLabel(this);
     }
   }
 

--- a/src/custom_typings/google_maps.d.ts
+++ b/src/custom_typings/google_maps.d.ts
@@ -21,12 +21,14 @@ declare module google.maps {
     setPosition(latLng: LatLng | LatLngLiteral): void;
     setTitle(title: string): void;
     setLabel(label: string | MarkerLabel): void;
+    getLabel(): MarkerLabel;
   }
 
   export interface MarkerOptions {
     position: LatLng | LatLngLiteral;
     title?: string;
     map?: Map;
+    label?: string | MarkerLabel;
   }
 
   export interface MarkerLabel {

--- a/src/services/marker_manager.ts
+++ b/src/services/marker_manager.ts
@@ -24,9 +24,17 @@ export class MarkerManager {
     return this._markers.get(marker).then((m: google.maps.Marker) => m.setTitle(marker.title));
   }
 
+  updateLabel(marker: SebmGoogleMapMarker): Promise<void> {
+    return this._markers.get(marker).then((m: google.maps.Marker) => {
+      const label = m.getLabel();
+      label.text = marker.label;
+      m.setLabel(label);
+    });
+  }
+
   addMarker(marker: SebmGoogleMapMarker) {
-    const markerPromise =
-        this._mapsWrapper.createMarker({position: {lat: marker.latitude, lng: marker.longitude}});
+    const markerPromise = this._mapsWrapper.createMarker(
+        {position: {lat: marker.latitude, lng: marker.longitude}, label: marker.label});
     this._markers.set(marker, markerPromise);
   }
 }


### PR DESCRIPTION
When using a `<sebm-google-map-marker>` inside a `<sebm-google-map>`, you
can now set a single-character label:

```html
 <sebm-google-map-marker [latitude]="lat" [longitude]="lng"
    [label]="myLabel"></sebm-google-map-marker>
```