### PR TITLE
fix(build): #59: use relative paths in bundleConfig

### DIFF
--- a/gulp/bundle.js
+++ b/gulp/bundle.js
@@ -9,8 +9,8 @@ const bundleConfig = {
   defaultJSExtensions: true,
   paths: {
     'angular2-google-maps/*': '*',
-    'angular2/*': path.join(__dirname, '../node_modules/angular2/*'),
-    'rxjs/*': path.join(__dirname, '../node_modules/rxjs/*'),
+    'angular2/*': './node_modules/angular2/*',
+    'rxjs/*': './node_modules/rxjs/*',
   },
 };
 


### PR DESCRIPTION
Relative paths in the bundleConfig also work on Windows.