### PR TITLE
feat(*): rename MapMouseEvent to MouseEvent

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -3,9 +3,10 @@ import {Provider} from 'angular2/core';
 import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 import {LazyMapsAPILoader} from './services/maps-api-loader/lazy-maps-api-loader';
 
-// main module
+// main modules
 export * from './directives';
 export * from './services';
+export * from './events';
 
 export const ANGULAR2_GOOGLE_MAPS_PROVIDERS: any[] = [
   new Provider(MapsAPILoader, {useClass: LazyMapsAPILoader}),

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -1,3 +1,3 @@
-export {SebmGoogleMap, MapMouseEvent} from './directives/google-map';
+export {SebmGoogleMap} from './directives/google-map';
 export {SebmGoogleMapMarker} from './directives/google-map-marker';
 export {ANGULAR2_GOOGLE_MAPS_DIRECTIVES} from './directives-const';

--- a/src/directives/google-map.ts
+++ b/src/directives/google-map.ts
@@ -1,7 +1,8 @@
 import {Component, ElementRef, EventEmitter, OnChanges, OnInit, SimpleChange} from 'angular2/core';
 import {GoogleMapsAPIWrapper} from '../services/google-maps-api-wrapper';
 import {MarkerManager} from '../services/marker-manager';
-import {LatLng, LatLngLiteral} from '../services/google-maps-types';
+import {LatLng} from '../services/google-maps-types';
+import {MouseEvent} from '../events';
 
 /**
  * SebMGoogleMap renders a Google Map.
@@ -63,19 +64,19 @@ export class SebmGoogleMap implements OnChanges,
    * This event emitter gets emitted when the user clicks on the map (but not when they click on a
    * marker or infoWindow).
    */
-  mapClick: EventEmitter<MapMouseEvent> = new EventEmitter<MapMouseEvent>();
+  mapClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
   /**
    * This event emitter gets emitted when the user right-clicks on the map (but not when they click
    * on a marker or infoWindow).
    */
-  mapRightClick: EventEmitter<MapMouseEvent> = new EventEmitter<MapMouseEvent>();
+  mapRightClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
   /**
    * This event emitter gets emitted when the user double-clicks on the map (but not when they click
    * on a marker or infoWindow).
    */
-  mapDblClick: EventEmitter<MapMouseEvent> = new EventEmitter<MapMouseEvent>();
+  mapDblClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
   constructor(private _elem: ElementRef, private _mapsWrapper: GoogleMapsAPIWrapper) {}
 
@@ -182,15 +183,9 @@ export class SebmGoogleMap implements OnChanges,
     events.forEach((e: Event) => {
       this._mapsWrapper.subscribeToMapEvent<{latLng: LatLng}>(e.name).subscribe(
           (event: {latLng: LatLng}) => {
-            const value =
-                <MapMouseEvent>{coords: {lat: event.latLng.lat(), lng: event.latLng.lng()}};
+            const value = <MouseEvent>{coords: {lat: event.latLng.lat(), lng: event.latLng.lng()}};
             e.emitter.emit(value);
           });
     });
   }
 }
-
-/**
- * MapMouseEvent gets emitted when the user triggers mouse events on the map.
- */
-export interface MapMouseEvent { coords: LatLngLiteral; }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,9 @@
+import {LatLngLiteral} from './services/google-maps-types';
+
+// exported map types
+export {LatLngLiteral} from './services/google-maps-types';
+
+/**
+ * MouseEvent gets emitted when the user triggers mouse events on the map.
+ */
+export interface MouseEvent { coords: LatLngLiteral; }


### PR DESCRIPTION
BREAKING CHANGE:

`MapMouseEvent` is now called `MouseEvent`. Please update your
imports:

before:
```
import {MapMouseEvent} from 'angular2-google-maps/core';
```

after:
```
import {MouseEvent} from 'angular2-google-maps/core';
```