### PR TITLE
add a getter for the map wrapper in the map directive

### DIFF
--- a/src/directives/google-map-marker.ts
+++ b/src/directives/google-map-marker.ts
@@ -1,12 +1,4 @@
-import {
-  Directive,
-  SimpleChange,
-  OnDestroy,
-  OnChanges,
-  EventEmitter,
-  ContentChild,
-  AfterContentInit
-} from 'angular2/core';
+import {Directive, SimpleChange, OnDestroy, OnChanges, EventEmitter, ContentChild, AfterContentInit} from 'angular2/core';
 import {MarkerManager} from '../services/marker-manager';
 import {SebmGoogleMapInfoWindow} from './google-map-info-window';
 import {MouseEvent} from '../events';

--- a/src/directives/google-map.ts
+++ b/src/directives/google-map.ts
@@ -191,6 +191,10 @@ export class SebmGoogleMap implements OnChanges,
     });
   }
 
+  get wrapper(): GoogleMapsAPIWrapper {
+    return this._mapsWrapper;
+  }
+  
   /**
    * Sets the zoom level of the map. The default value is `8`.
    */

--- a/src/directives/google-map.ts
+++ b/src/directives/google-map.ts
@@ -191,14 +191,12 @@ export class SebmGoogleMap implements OnChanges,
     });
   }
 
-  get wrapper(): GoogleMapsAPIWrapper {
-    return this._mapsWrapper;
-  }
-  
+  get wrapper(): GoogleMapsAPIWrapper { return this._mapsWrapper; }
+
   /**
    * Sets the zoom level of the map. The default value is `8`.
    */
-  set zoom(value: number | string) {
+  set zoom(value: number|string) {
     this._zoom = this._convertToDecimal(value, 8);
     if (typeof this._zoom === 'number') {
       this._mapsWrapper.setZoom(this._zoom);
@@ -208,7 +206,7 @@ export class SebmGoogleMap implements OnChanges,
   /**
    * The longitude that sets the center of the map.
    */
-  set longitude(value: number | string) {
+  set longitude(value: number|string) {
     this._longitude = this._convertToDecimal(value);
     this._updateCenter();
   }
@@ -216,12 +214,12 @@ export class SebmGoogleMap implements OnChanges,
   /**
    * The latitude that sets the center of the map.
    */
-  set latitude(value: number | string) {
+  set latitude(value: number|string) {
     this._latitude = this._convertToDecimal(value);
     this._updateCenter();
   }
 
-  private _convertToDecimal(value: string | number, defaultValue: number = null): number {
+  private _convertToDecimal(value: string|number, defaultValue: number = null): number {
     if (typeof value === 'string') {
       return parseFloat(value);
     } else if (typeof value === 'number') {

--- a/src/services.ts
+++ b/src/services.ts
@@ -3,8 +3,4 @@ export {NoOpMapsAPILoader} from './services/maps-api-loader/noop-maps-api-loader
 export {GoogleMapsAPIWrapper} from './services/google-maps-api-wrapper';
 export {MarkerManager} from './services/marker-manager';
 export {InfoWindowManager} from './services/info-window-manager';
-export {
-  LazyMapsAPILoader,
-  LazyMapsAPILoaderConfig,
-  GoogleMapsScriptProtocol
-} from './services/maps-api-loader/lazy-maps-api-loader';
+export {LazyMapsAPILoader, LazyMapsAPILoaderConfig, GoogleMapsScriptProtocol} from './services/maps-api-loader/lazy-maps-api-loader';

--- a/src/services/google-maps-types.ts
+++ b/src/services/google-maps-types.ts
@@ -2,11 +2,11 @@ export var google: any;
 
 export interface GoogleMap {
   constructor(el: HTMLElement, opts?: MapOptions): void;
-  panTo(latLng: LatLng | LatLngLiteral): void;
+  panTo(latLng: LatLng|LatLngLiteral): void;
   setZoom(zoom: number): void;
   addListener(eventName: string, fn: Function): void;
   getCenter(): LatLng;
-  setCenter(latLng: LatLng | LatLngLiteral): void;
+  setCenter(latLng: LatLng|LatLngLiteral): void;
   getZoom(): number;
   setOptions(options: MapOptions): void;
 }
@@ -20,9 +20,9 @@ export interface LatLng {
 export interface Marker {
   constructor(options?: MarkerOptions): void;
   setMap(map: GoogleMap): void;
-  setPosition(latLng: LatLng | LatLngLiteral): void;
+  setPosition(latLng: LatLng|LatLngLiteral): void;
   setTitle(title: string): void;
-  setLabel(label: string | MarkerLabel): void;
+  setLabel(label: string|MarkerLabel): void;
   setDraggable(draggable: boolean): void;
   setIcon(icon: string): void;
   getLabel(): MarkerLabel;
@@ -30,10 +30,10 @@ export interface Marker {
 }
 
 export interface MarkerOptions {
-  position: LatLng | LatLngLiteral;
+  position: LatLng|LatLngLiteral;
   title?: string;
   map?: GoogleMap;
-  label?: string | MarkerLabel;
+  label?: string|MarkerLabel;
   draggable?: boolean;
   icon?: string;
 }
@@ -54,7 +54,7 @@ export interface LatLngLiteral {
 export interface MouseEvent { latLng: LatLng; }
 
 export interface MapOptions {
-  center?: LatLng | LatLngLiteral;
+  center?: LatLng|LatLngLiteral;
   zoom?: number;
   disableDoubleClickZoom?: boolean;
   disableDefaultUI?: boolean;
@@ -68,13 +68,13 @@ export interface MapOptions {
 export interface InfoWindow {
   constructor(opts?: InfoWindowOptions): void;
   close(): void;
-  getContent(): string | Node;
+  getContent(): string|Node;
   getPosition(): LatLng;
   getZIndex(): number;
   open(map?: GoogleMap, anchor?: MVCObject): void;
-  setContent(content: string | Node): void;
+  setContent(content: string|Node): void;
   setOptions(options: InfoWindowOptions): void;
-  setPosition(position: LatLng | LatLngLiteral): void;
+  setPosition(position: LatLng|LatLngLiteral): void;
   setZIndex(zIndex: number): void;
 }
 
@@ -89,10 +89,10 @@ export interface Size {
 }
 
 export interface InfoWindowOptions {
-  content?: string | Node;
+  content?: string|Node;
   disableAutoPan?: boolean;
   maxWidth?: number;
   pixelOffset?: Size;
-  position?: LatLng | LatLngLiteral;
+  position?: LatLng|LatLngLiteral;
   zIndex?: number;
 }


### PR DESCRIPTION
Allow the GoogleMapsAPIWrapper instance used in the directive to be retrieved.

Since the provider is overridden per map instance, I haven't found a way to access the same GoogleMapsAPIWrapper instance as injecting it into my component gives me a new instance, even if provided at the app bootstrap level.

I get that with multiple maps on the page we really don't want only a single api wrapper to be available, hence the provider on the directive level, however, it would be incredibly useful to gain access to that api wrapper instance in order to call `getMap()` on it and so on.