### PR TITLE
feat(*): rename ANGULAR2_GOOGLE_MAPS_* constants

### DIFF
--- a/docs/_partials/homepage/quickstart-example.ejs
+++ b/docs/_partials/homepage/quickstart-example.ejs
@@ -2,13 +2,13 @@ import {Component} from '@angular/core';
 import {bootstrap} from '@angular/platform-browser-dynamic';
 
 import {
-ANGULAR2_GOOGLE_MAPS_DIRECTIVES,
-ANGULAR2_GOOGLE_MAPS_PROVIDERS
+GOOGLE_MAPS_DIRECTIVES,
+GOOGLE_MAPS_PROVIDERS
 } from 'angular2-google-maps/core';
 
 @Component({
 	selector: 'app-component',
-	directives: [ANGULAR2_GOOGLE_MAPS_DIRECTIVES]
+	directives: [GOOGLE_MAPS_DIRECTIVES]
 	template: `
 		&lt;sebm-google-map [latitude]=&quot;lat&quot; [longitude]=&quot;lng&quot;&gt;
 		&lt;/sebm-google-map&gt;
@@ -19,4 +19,4 @@ class AppComponent {
 	lng: number = 33.2;
 }
 
-bootstrap(AppComponent, [ANGULAR2_GOOGLE_MAPS_PROVIDERS]);
+bootstrap(AppComponent, [GOOGLE_MAPS_PROVIDERS]);

--- a/docs/getting-started.jade
+++ b/docs/getting-started.jade
@@ -344,11 +344,11 @@ a.button.button-icon.blue-light(href='http://plnkr.co/edit/YX7W20?p=preview') &r
   :marked
     ```typescript
     import {Component} from '@angular/core';
-    import {ANGULAR2_GOOGLE_MAPS_DIRECTIVES} from 'angular2-google-maps/core';
+    import {GOOGLE_MAPS_DIRECTIVES} from 'angular2-google-maps/core';
 
     @Component({
       selector: 'my-app',
-      directives: [ANGULAR2_GOOGLE_MAPS_DIRECTIVES], // this loads all angular2-google-maps directives in this component
+      directives: [GOOGLE_MAPS_DIRECTIVES], // this loads all angular2-google-maps directives in this component
       // the following line sets the height of the map - Important: if you don't set a height, you won't see a map!!
       styles: [`
         .sebm-google-map-container {
@@ -385,11 +385,11 @@ a.button.button-icon.blue-light(href='http://plnkr.co/edit/YX7W20?p=preview') &r
     ```typescript
     import {bootstrap}    from '@angular/platform-browser-dynamic';
     import {AppComponent} from './app.component';
-    import {ANGULAR2_GOOGLE_MAPS_PROVIDERS} from 'angular2-google-maps/core';
+    import {GOOGLE_MAPS_PROVIDERS} from 'angular2-google-maps/core';
 
     // this line boots our application on the page in the <my-app> element:
-    // Note: It is required to add the ANGULAR2_GOOGLE_MAPS_PROVIDERS here!
-    bootstrap(AppComponent, [ANGULAR2_GOOGLE_MAPS_PROVIDERS]);
+    // Note: It is required to add the GOOGLE_MAPS_PROVIDERS here!
+    bootstrap(AppComponent, [GOOGLE_MAPS_PROVIDERS]);
     ```
     ### Final project structure
     Our final project structure should look like this:

--- a/src/core/directives-const.ts
+++ b/src/core/directives-const.ts
@@ -2,5 +2,5 @@ import {SebmGoogleMap} from './directives/google-map';
 import {SebmGoogleMapInfoWindow} from './directives/google-map-info-window';
 import {SebmGoogleMapMarker} from './directives/google-map-marker';
 
-export const ANGULAR2_GOOGLE_MAPS_DIRECTIVES: any[] =
+export const GOOGLE_MAPS_DIRECTIVES: any[] =
     [SebmGoogleMap, SebmGoogleMapMarker, SebmGoogleMapInfoWindow];

--- a/src/core/directives.ts
+++ b/src/core/directives.ts
@@ -1,4 +1,4 @@
-export {ANGULAR2_GOOGLE_MAPS_DIRECTIVES} from './directives-const';
+export {GOOGLE_MAPS_DIRECTIVES} from './directives-const';
 export {SebmGoogleMap} from './directives/google-map';
 export {SebmGoogleMapInfoWindow} from './directives/google-map-info-window';
 export {SebmGoogleMapMarker} from './directives/google-map-marker';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -8,6 +8,6 @@ export * from './directives';
 export * from './services';
 export * from './events';
 
-export const ANGULAR2_GOOGLE_MAPS_PROVIDERS: any[] = [
+export const GOOGLE_MAPS_PROVIDERS: any[] = [
   new Provider(MapsAPILoader, {useClass: LazyMapsAPILoader}),
 ];


### PR DESCRIPTION
This removes the ANGULAR2_ prefix.

BREAKING CHANGES

`ANGULAR2_GOOGLE_MAPS_PROVIDERS` is now called `GOOGLE_MAPS_PROVIDERS`.
`ANGULAR2_GOOGLE_MAPS_DIRECTIVES`is now called `GOOGLE_MAPS_DIRECTIVES`.

Please update existing import of these two constants in your code.

Related to #395