### PR TITLE
feat(SebmGoogleMap): support panning

### DIFF
--- a/src/core/services/google-maps-api-wrapper.ts
+++ b/src/core/services/google-maps-api-wrapper.ts
@@ -71,6 +71,10 @@ export class GoogleMapsAPIWrapper {
     return this._map.then((map: mapTypes.GoogleMap) => map.getCenter());
   }
 
+  panTo(latLng: mapTypes.LatLng|mapTypes.LatLngLiteral): Promise<void> {
+    return this._map.then((map) => map.panTo(latLng));
+  }
+
   /**
    * Returns the native Google Maps Map instance. Be careful when using this instance directly.
    */


### PR DESCRIPTION
You can now use the panning feature of Google Maps when use
`usePanning` binding:

```
<sebm-google-map <sebm-google-map [latitude]="lat" [longitude]="lng"
[zoom]="9" [usePanning]="true">
</sebm-google-map>
```

When latitude/latitude values change and usePanning is true,
the map uses the `panTo()` method of Google Maps.

BREAKING CHANGES:

The latitude, longitude and zoom inputs of <sebm-google-map> must be of type number now.
Strings are not supported any more.

Example:

Old (now unsuported way):
```
<sebm-google-map latitude="33" longitude="22" zoom="8">...
```

New:
```
<sebm-google-map [latitude]="33" [longitude]="22" [zoom]="8">...
```