### PR TITLE
feat(LazyMapsAPILoader): provide shortcut

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,9 @@
-import {Provider} from '@angular/core';
+import {provide} from '@angular/core';
 
 import {LazyMapsAPILoader} from './services/maps-api-loader/lazy-maps-api-loader';
 import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
+
+import {BROWSER_GLOBALS_PROVIDERS} from './utils/browser-globals';
 
 // main modules
 export * from './directives';
@@ -9,5 +11,6 @@ export * from './services';
 export * from './events';
 
 export const GOOGLE_MAPS_PROVIDERS: any[] = [
-  new Provider(MapsAPILoader, {useClass: LazyMapsAPILoader}),
+  ...BROWSER_GLOBALS_PROVIDERS,
+  provide(MapsAPILoader, {useClass: LazyMapsAPILoader}),
 ];

--- a/src/core/services.ts
+++ b/src/core/services.ts
@@ -1,6 +1,6 @@
 export {GoogleMapsAPIWrapper} from './services/google-maps-api-wrapper';
 export {InfoWindowManager} from './services/info-window-manager';
-export {GoogleMapsScriptProtocol, LazyMapsAPILoader, LazyMapsAPILoaderConfig} from './services/maps-api-loader/lazy-maps-api-loader';
+export {GoogleMapsScriptProtocol, LazyMapsAPILoader, LazyMapsAPILoaderConfig, LazyMapsAPILoaderConfigLiteral, provideLazyMapsAPILoaderConfig} from './services/maps-api-loader/lazy-maps-api-loader';
 export {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
 export {NoOpMapsAPILoader} from './services/maps-api-loader/noop-maps-api-loader';
 export {MarkerManager} from './services/marker-manager';

--- a/src/core/utils/browser-globals.ts
+++ b/src/core/utils/browser-globals.ts
@@ -1,0 +1,4 @@
+import {Provider, provide} from '@angular/core';
+
+export const BROWSER_GLOBALS_PROVIDERS: Provider[] =
+    [provide(Window, {useValue: window}), provide(Document, {useValue: document})];

--- a/test/services/maps-api-loader/lazy-maps-api-loader.spec.ts
+++ b/test/services/maps-api-loader/lazy-maps-api-loader.spec.ts
@@ -1,0 +1,41 @@
+import {provide} from '@angular/core';
+import {beforeEachProviders, describe, expect, inject, it} from '@angular/core/testing';
+
+import {LazyMapsAPILoader} from '../../../src/core/services/maps-api-loader/lazy-maps-api-loader';
+import {MapsAPILoader} from '../../../src/core/services/maps-api-loader/maps-api-loader';
+
+export function main() {
+  describe('Service: LazyMapsAPILoader', () => {
+    beforeEachProviders(() => {
+      return [
+        provide(MapsAPILoader, {useClass: LazyMapsAPILoader}), provide(Window, {useValue: {}}),
+        provide(
+            Document, {useValue: jasmine.createSpyObj<Document>('Document', ['createElement'])})
+      ];
+    });
+
+    it('should create the default script URL',
+       inject([MapsAPILoader, Document, Window], (loader: LazyMapsAPILoader, doc: Document) => {
+         interface Script {
+           src?: string;
+           async?: boolean;
+           defer?: boolean;
+           type?: string;
+         }
+         const scriptElem: Script = {};
+         (<jasmine.Spy>doc.createElement).and.returnValue(scriptElem);
+         doc.body = jasmine.createSpyObj('body', ['appendChild']);
+
+         loader.load();
+         expect(doc.createElement).toHaveBeenCalled();
+         expect(scriptElem.type).toEqual('text/javascript');
+         expect(scriptElem.async).toEqual(true);
+         expect(scriptElem.defer).toEqual(true);
+         expect(scriptElem.src).toBeDefined();
+         expect(scriptElem.src).toContain('https://maps.googleapis.com/maps/api/js');
+         expect(scriptElem.src).toContain('v=3');
+         expect(scriptElem.src).toContain('callback=angular2GoogleMapsLazyMapsAPILoader');
+         expect(doc.body.appendChild).toHaveBeenCalledWith(scriptElem);
+       }));
+  });
+}


### PR DESCRIPTION
Now, you can use a shortcut to configure the LazyMapsAPILoader:

Before:
```typescript
bootstrap(AppComponent, [
  ANGULAR2_GOOGLE_MAPS_PROVIDERS,
  provide(LazyMapsAPILoaderConfig, {useFactory: () => {
    let config = new LazyMapsAPILoaderConfig();
    config.apiKey = 'mykey';
    return config;
  }})
])
```

After:
```typescript
import {provide} from 'angular2/core';
import {provideLazyMapsAPILoaderConfig} from
'angular2-google-maps/core';

bootstrap(AppComponent, [
  GOOGLE_MAPS_PROVIDERS,
  provideLazyMapsAPILoaderConfig({ apiKey: 'myKey' })
])
```

Closes #388