### PR TITLE
fix(LazyMapsAPILoader): use OpaqueTokens for globs

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,6 +11,6 @@ export * from './services';
 export * from './events';
 
 export const GOOGLE_MAPS_PROVIDERS: any[] = [
-  ...BROWSER_GLOBALS_PROVIDERS,
+  BROWSER_GLOBALS_PROVIDERS,
   provide(MapsAPILoader, {useClass: LazyMapsAPILoader}),
 ];

--- a/src/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/src/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -1,4 +1,6 @@
-import {Injectable, Optional, Provider, provide} from '@angular/core';
+import {Inject, Injectable, Optional, Provider, provide} from '@angular/core';
+
+import {DOCUMENT_GLOBAL, WINDOW_GLOBAL} from '../../utils/browser-globals';
 
 import {MapsAPILoader} from './maps-api-loader';
 
@@ -95,7 +97,9 @@ export class LazyMapsAPILoader extends MapsAPILoader {
   private _window: Window;
   private _document: Document;
 
-  constructor(@Optional() config: LazyMapsAPILoaderConfig, w: Window, d: Document) {
+  constructor(
+      @Optional() config: LazyMapsAPILoaderConfig, @Inject(WINDOW_GLOBAL) w: Window,
+      @Inject(DOCUMENT_GLOBAL) d: Document) {
     super();
     this._config = config || DEFAULT_CONFIGURATION;
     this._window = w;

--- a/src/core/utils/browser-globals.ts
+++ b/src/core/utils/browser-globals.ts
@@ -1,4 +1,7 @@
-import {Provider, provide} from '@angular/core';
+import {OpaqueToken, Provider, provide} from '@angular/core';
+
+export const WINDOW_GLOBAL = new OpaqueToken('angular2-google-maps window_global');
+export const DOCUMENT_GLOBAL = new OpaqueToken('angular2-google-maps document_global');
 
 export const BROWSER_GLOBALS_PROVIDERS: Provider[] =
-    [provide(Window, {useValue: window}), provide(Document, {useValue: document})];
+    [provide(WINDOW_GLOBAL, {useValue: window}), provide(DOCUMENT_GLOBAL, {useValue: document})];

--- a/test/services/maps-api-loader/lazy-maps-api-loader.spec.ts
+++ b/test/services/maps-api-loader/lazy-maps-api-loader.spec.ts
@@ -3,19 +3,21 @@ import {beforeEachProviders, describe, expect, inject, it} from '@angular/core/t
 
 import {LazyMapsAPILoader} from '../../../src/core/services/maps-api-loader/lazy-maps-api-loader';
 import {MapsAPILoader} from '../../../src/core/services/maps-api-loader/maps-api-loader';
+import {DOCUMENT_GLOBAL, WINDOW_GLOBAL} from '../../../src/core/utils/browser-globals';
 
 export function main() {
   describe('Service: LazyMapsAPILoader', () => {
     beforeEachProviders(() => {
       return [
-        provide(MapsAPILoader, {useClass: LazyMapsAPILoader}), provide(Window, {useValue: {}}),
-        provide(
-            Document, {useValue: jasmine.createSpyObj<Document>('Document', ['createElement'])})
+        provide(MapsAPILoader, {useClass: LazyMapsAPILoader}),
+        provide(WINDOW_GLOBAL, {useValue: {}}), provide(DOCUMENT_GLOBAL, {
+          useValue: jasmine.createSpyObj<Document>('Document', ['createElement'])
+        })
       ];
     });
 
     it('should create the default script URL',
-       inject([MapsAPILoader, Document, Window], (loader: LazyMapsAPILoader, doc: Document) => {
+       inject([MapsAPILoader, DOCUMENT_GLOBAL], (loader: LazyMapsAPILoader, doc: Document) => {
          interface Script {
            src?: string;
            async?: boolean;


### PR DESCRIPTION
The Interfaces Window and Document seem not to work in all
enviroments, so we now use OpaqueTokens to make sure that
it's working in all cases.