### PR TITLE
Feature option for marker infowindow click 424

### DIFF
--- a/src/core/directives/google-map-marker.ts
+++ b/src/core/directives/google-map-marker.ts
@@ -35,7 +35,10 @@ let markerId = 0;
  */
 @Directive({
   selector: 'sebm-google-map-marker',
-  inputs: ['latitude', 'longitude', 'title', 'label', 'draggable: markerDraggable', 'iconUrl'],
+  inputs: [
+    'latitude', 'longitude', 'title', 'label', 'draggable: markerDraggable', 'iconUrl',
+    'openInfoWindow'
+  ],
   outputs: ['markerClick', 'dragEnd']
 })
 export class SebmGoogleMapMarker implements OnDestroy,
@@ -69,6 +72,11 @@ export class SebmGoogleMapMarker implements OnDestroy,
    * Icon (the URL of the image) for the foreground.
    */
   iconUrl: string;
+
+  /**
+   * Whether to automatically open the child info window when the marker is clicked.
+   */
+  openInfoWindow: boolean = true;
 
   /**
    * This event emitter gets emitted when the user clicks on the marker.
@@ -124,14 +132,14 @@ export class SebmGoogleMapMarker implements OnDestroy,
 
   private _addEventListeners() {
     this._markerManager.createEventObservable('click', this).subscribe(() => {
-      if (this._infoWindow != null) {
+      if (this.openInfoWindow && this._infoWindow != null) {
         this._infoWindow.open();
       }
       this.markerClick.emit(null);
     });
     this._markerManager.createEventObservable<mapTypes.MouseEvent>('dragend', this)
         .subscribe((e: mapTypes.MouseEvent) => {
-          this.dragEnd.emit({coords: {lat: e.latLng.lat(), lng: e.latLng.lng()}} as mapTypes.MouseEvent);
+          this.dragEnd.emit({coords: {lat: e.latLng.lat(), lng: e.latLng.lng()}});
         });
   }
 

--- a/src/core/directives/google-map-marker.ts
+++ b/src/core/directives/google-map-marker.ts
@@ -127,11 +127,11 @@ export class SebmGoogleMapMarker implements OnDestroy,
       if (this._infoWindow != null) {
         this._infoWindow.open();
       }
-      this.markerClick.next(null);
+      this.markerClick.emit(null);
     });
     this._markerManager.createEventObservable<mapTypes.MouseEvent>('dragend', this)
         .subscribe((e: mapTypes.MouseEvent) => {
-          this.dragEnd.next({coords: {lat: e.latLng.lat(), lng: e.latLng.lng()}});
+          this.dragEnd.emit({coords: {lat: e.latLng.lat(), lng: e.latLng.lng()}} as mapTypes.MouseEvent);
         });
   }
 


### PR DESCRIPTION
Fixes #424 

@SebastianM I have a couple comments:

1 - I updated EventEmitter calls to use `emit()` instead of the deprecated  `next()` method in the SebmGoogleMapMarker

2 - Off topic but I noticed it doing this: In the marker manager, don't we need to cleanup added events when the marker is removed?

Thanks!