### PR TITLE
feat(*): support @NgModule

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,8 @@
     "@angular/common": "2.0.0-rc.5",
     "@angular/compiler": "2.0.0-rc.5",
     "@angular/core": "2.0.0-rc.5",
-    "@angular/http": "2.0.0-rc.5",
     "@angular/platform-browser": "2.0.0-rc.5",
     "@angular/platform-browser-dynamic": "2.0.0-rc.5",
-    "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12"
@@ -76,10 +74,8 @@
       "@angular/common": "2.0.0-rc.5",
       "@angular/compiler": "2.0.0-rc.5",
       "@angular/core": "2.0.0-rc.5",
-      "@angular/http": "2.0.0-rc.5",
       "@angular/platform-browser": "2.0.0-rc.5",
       "@angular/platform-browser-dynamic": "2.0.0-rc.5",
-      "core-js": "^2.4.0",
       "reflect-metadata": "^0.1.3",
       "rxjs": "5.0.0-beta.6",
       "zone.js": "^0.6.12"

--- a/src/core/directives-const.ts
+++ b/src/core/directives-const.ts
@@ -5,6 +5,7 @@ import {SebmGoogleMapMarker} from './directives/google-map-marker';
 import {SebmGoogleMapPolyline} from './directives/google-map-polyline';
 import {SebmGoogleMapPolylinePoint} from './directives/google-map-polyline-point';
 
+/** @deprecated */
 export const GOOGLE_MAPS_DIRECTIVES: any[] = [
   SebmGoogleMap, SebmGoogleMapMarker, SebmGoogleMapInfoWindow, SebmGoogleMapCircle,
   SebmGoogleMapPolyline, SebmGoogleMapPolylinePoint

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,8 +1,8 @@
-import {provide} from '@angular/core';
+import {ModuleWithProviders, NgModule, provide} from '@angular/core';
 
+import {GOOGLE_MAPS_DIRECTIVES} from './directives-const';
 import {LazyMapsAPILoader} from './services/maps-api-loader/lazy-maps-api-loader';
 import {MapsAPILoader} from './services/maps-api-loader/maps-api-loader';
-
 import {BROWSER_GLOBALS_PROVIDERS} from './utils/browser-globals';
 
 // main modules
@@ -13,7 +13,24 @@ export * from './map-types';
 // Google Maps types
 export {LatLngBounds, LatLng, LatLngLiteral, MapTypeStyle} from './services/google-maps-types';
 
+/** @deprecated */
 export const GOOGLE_MAPS_PROVIDERS: any[] = [
   BROWSER_GLOBALS_PROVIDERS,
   provide(MapsAPILoader, {useClass: LazyMapsAPILoader}),
 ];
+
+/**
+ * The angular2-google-maps core module. Contains all Directives/Services/Pipes
+ * of the core module. Please use `AgmCoreModule.forRoot()` in your app module.
+ *
+ * @experimental
+ */
+@NgModule({declarations: GOOGLE_MAPS_DIRECTIVES, exports: GOOGLE_MAPS_DIRECTIVES})
+export class AgmCoreModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: AgmCoreModule,
+      providers: GOOGLE_MAPS_PROVIDERS,
+    };
+  }
+}


### PR DESCRIPTION
This adds a new NgModule to the project. The Module name for the
core package is `AgmCoreModule`. This feature is experimental.

Example:

```typescript
import { NgModule } from '@angular/core';
import { BrowserModule } from '@angular/platform-browser';
import { platformBrowserDynamic } from
'@angular/platform-browser-dynamic';
import { MyMapsProjectAppComponent } from './app/';

import {AgmCoreModule} from 'angular2-google-maps/core';

@NgModule({
	  imports: [BrowserModule, AgmCoreModule.forRoot()],
		declarations: [MyMapsProjectAppComponent],
	  bootstrap: [MyMapsProjectAppComponent]
})
export class AppModule {
}

platformBrowserDynamic().bootstrapModule(AppModule);
```

Closes #560