### PR TITLE
Fix inability to use HTTP protocol

### DIFF
--- a/src/core/services/maps-api-loader/lazy-maps-api-loader.ts
+++ b/src/core/services/maps-api-loader/lazy-maps-api-loader.ts
@@ -5,9 +5,9 @@ import {DOCUMENT_GLOBAL, WINDOW_GLOBAL} from '../../utils/browser-globals';
 import {MapsAPILoader} from './maps-api-loader';
 
 export enum GoogleMapsScriptProtocol {
-  HTTP,
-  HTTPS,
-  AUTO
+  HTTP = 1,
+  HTTPS = 2,
+  AUTO = 3
 }
 
 /**


### PR DESCRIPTION
There was an error where 

>       config.protocol = config.protocol || DEFAULT_CONFIGURATION.protocol;
would always used DEFAULT_CONFIGURATION.protocol.

GoogleMapsScriptProtocol.HTTP would default to 0 (how typescript handles enums), so (0 || DEFAULT_CONFIGURATION.protocol) would always evaluate to DEFAULT_CONFIGURATION.protocol.

Setting the enum values as non 0 values fixes this issue