### PR TITLE
Update to Angular 2 RC7

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/SebastianM/angular2-google-maps#readme",
   "dependencies": {
-    "@angular/common": "2.0.0-rc.6",
-    "@angular/compiler": "2.0.0-rc.6",
-    "@angular/core": "2.0.0-rc.6",
-    "@angular/platform-browser": "2.0.0-rc.6",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
-    "rxjs": "5.0.0-beta.11",
-    "zone.js": "^0.6.17"
+    "@angular/common": "2.0.0-rc.7",
+    "@angular/compiler": "2.0.0-rc.7",
+    "@angular/core": "2.0.0-rc.7",
+    "@angular/platform-browser": "2.0.0-rc.7",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.7",
+    "rxjs": "5.0.0-beta.12",
+    "zone.js": "^0.6.21"
   },
   "devDependencies": {
     "babel-eslint": "6.0.4",
@@ -70,13 +70,13 @@
   "jspm": {
     "jspmNodeConversion": false,
     "dependencies": {
-      "@angular/common": "2.0.0-rc.6",
-      "@angular/compiler": "2.0.0-rc.6",
-      "@angular/core": "2.0.0-rc.6",
-      "@angular/platform-browser": "2.0.0-rc.6",
-      "@angular/platform-browser-dynamic": "2.0.0-rc.6",
+      "@angular/common": "2.0.0-rc.7",
+      "@angular/compiler": "2.0.0-rc.7",
+      "@angular/core": "2.0.0-rc.7",
+      "@angular/platform-browser": "2.0.0-rc.7",
+      "@angular/platform-browser-dynamic": "2.0.0-rc.7",
       "rxjs": "5.0.0-beta.11",
-      "zone.js": "^0.6.17"
+      "zone.js": "^0.6.21"
     }
   }
 }


### PR DESCRIPTION
Upgraded just the dependencies to Angular 2 RC7.

Tested in a project using Angular 2 RC7 with:
`npm install --save "jussikinnula/angular2-google-maps-build#0.0.3"`

Note! At the moment it seems that the master (without Angular 2 RC7 package updates) does not test properly (e.g. `gulp build` works, but `gulp test` gives Promise-related fatal errors). Fixing the testing related errors should be done prior getting this pull request in (testing should work always in `master` with `gulp test`).