### PR TITLE
Re-implements mapDblClick event

### DIFF
--- a/src/core/directives/map.ts
+++ b/src/core/directives/map.ts
@@ -460,6 +460,7 @@ export class AgmMap implements OnChanges, OnInit, OnDestroy {
     const events: Event[] = [
       {name: 'click', emitter: this.mapClick},
       {name: 'rightclick', emitter: this.mapRightClick},
+      {name: 'dblclick', emitter: this.mapDblClick},
     ];
 
     events.forEach((e: Event) => {


### PR DESCRIPTION
The mouse event emitter was missing for mapDblClick - this should solve the issue but is untested. Should resolve #879