### PR TITLE
fix: add MarkerLabel union type to marker label attribute

### DIFF
--- a/src/core/directives/marker.ts
+++ b/src/core/directives/marker.ts
@@ -59,9 +59,10 @@ export class AgmMarker implements OnDestroy, OnChanges, AfterContentInit {
 
   /**
    * The label (a single uppercase character) for the marker.
+   * Alternatively, a MarkerLabel object may be provided.
    */
-  label: string;
-
+  label: string | mapTypes.MarkerLabel;
+  
   /**
    * If true, the marker can be dragged. Default value is false.
    */


### PR DESCRIPTION
According to google maps api documentation, the label attribute
of a marker can take either a string or a MarkerLabel object.
Update Marker directive with a union type for label attribute
which accepts either a string or a MarkerLabel.

non-breaking change